### PR TITLE
Fix NPE

### DIFF
--- a/src/main/java/com/aliyun/openservices/log/flink/FlinkLogConsumer.java
+++ b/src/main/java/com/aliyun/openservices/log/flink/FlinkLogConsumer.java
@@ -116,7 +116,7 @@ public class FlinkLogConsumer<T> extends RichParallelSourceFunction<T> implement
 
                             cursorStateForCheckpoint.add(Tuple2.of(entry.getKey(), entry.getValue()));
                             if (consumerGroupName != null) {
-                                logClient.updateCheckpoint(fetcher.getLogProject(), fetcher.getLogStore(), consumerGroupName, "flinkTask-" + getRuntimeContext().getIndexOfThisSubtask() + "Of" + getRuntimeContext().getNumberOfParallelSubtasks(), entry.getKey().getShardId(), entry.getValue());
+                                logClient.updateCheckpoint(logProject, logStore, consumerGroupName, "flinkTask-" + getRuntimeContext().getIndexOfThisSubtask() + "Of" + getRuntimeContext().getNumberOfParallelSubtasks(), entry.getKey().getShardId(), entry.getValue());
                             }
                         }
                     }
@@ -127,7 +127,7 @@ public class FlinkLogConsumer<T> extends RichParallelSourceFunction<T> implement
                 if (LOG.isDebugEnabled()) {
                     StringBuilder strb = new StringBuilder();
                     for(Map.Entry<LogstoreShardMeta, String> entry: lastStateSnapshot.entrySet()){
-                        strb.append("shard: " + entry.getKey().toString() + ", cursor: " +entry.getValue());
+                        strb.append("shard: ").append(entry.getKey().toString()).append(", cursor: ").append(entry.getValue());
                     }
                     LOG.debug("Snapshotted state, last processed cursor: {}, checkpoint id: {}, timestamp: {}",
                             strb, context.getCheckpointId(), context.getCheckpointTimestamp());


### PR DESCRIPTION
The only place to initialize the ```fetcher``` object is: 
https://github.com/aliyun/aliyun-log-flink-connector/blob/454496e682bb47fc505b89fbe15e805e45b76db0/src/main/java/com/aliyun/openservices/log/flink/FlinkLogConsumer.java#L55

And from the constructor of class ```LogDataFetcher```:
https://github.com/aliyun/aliyun-log-flink-connector/blob/454496e682bb47fc505b89fbe15e805e45b76db0/src/main/java/com/aliyun/openservices/log/flink/model/LogDataFetcher.java#L53

We can know the fields ```logProject``` and ```logStore``` of fetcher are read from config which was used to read ```logProject``` and ```logStore``` in class ```FlinkLogConsumer```, which means we can just use the current  ```logProject``` and ```logStore``` to replace ```fetcher.getLogProject(), fetcher.getLogStore()```. 

Closes #2 
